### PR TITLE
Added hard reset conditions to RabbitMQ connections in the Adapter and Dispatcher

### DIFF
--- a/cmd/dispatcher/main.go
+++ b/cmd/dispatcher/main.go
@@ -104,7 +104,7 @@ func main() {
 	}
 
 	var err error
-	rmqHelper := rabbit.NewRabbitMQConnectionHandler(1000, logger)
+	rmqHelper := rabbit.NewRabbitMQConnectionHandler(5, 1000, logger)
 	rmqHelper.Setup(ctx, rabbit.VHostHandler(
 		env.RabbitURL,
 		env.RabbitMQVhost),

--- a/cmd/ingress/main.go
+++ b/cmd/ingress/main.go
@@ -91,7 +91,7 @@ func main() {
 		logger.Errorw("failed to create the metrics exporter", zap.Error(err))
 	}
 
-	env.rmqHelper = rabbit.NewRabbitMQConnectionHandler(1000, logger)
+	env.rmqHelper = rabbit.NewRabbitMQConnectionHandler(5, 1000, logger)
 	env.rmqHelper.Setup(ctx, rabbit.VHostHandler(env.BrokerURL, env.RabbitMQVhost), rabbit.ChannelConfirm, rabbit.DialWrapper)
 
 	env.reporter = ingress.NewStatsReporter(env.ContainerName, kmeta.ChildName(env.PodName, uuid.New().String()))

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -98,7 +98,7 @@ func (a *Adapter) start(stopCh <-chan struct{}) error {
 		zap.String("SinkURI", a.config.Sink))
 
 	if a.rmqHelper == nil {
-		a.rmqHelper = rabbit.NewRabbitMQConnectionHandler(1000, logger)
+		a.rmqHelper = rabbit.NewRabbitMQConnectionHandler(5, 1000, logger)
 		a.rmqHelper.Setup(a.context, rabbit.VHostHandler(a.config.RabbitURL, a.config.Vhost), rabbit.ChannelQoS, rabbit.DialWrapper)
 	}
 	return a.PollForMessages(stopCh)

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -250,7 +250,7 @@ func TestAdapter_PollForMessages(t *testing.T) {
 		context:   ctx,
 		logger:    zap.NewNop(),
 		reporter:  statsReporter,
-		rmqHelper: rabbit.NewRabbitMQConnectionHandler(500, zap.NewNop().Sugar()),
+		rmqHelper: rabbit.NewRabbitMQConnectionHandler(5, 500, zap.NewNop().Sugar()),
 	}
 	a.rmqHelper.Setup(ctx, "", nil, rabbit.ValidDial)
 


### PR DESCRIPTION
fixes #1175 #1214

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Added hard reset directives to the RabbitMQ connections, so the pods restart whenever the soft resets fails too many times, so the whole system status is clear for the user and some other edge cases are solved by just restarting every pod that needs a connection to the RabbitMQ Cluster

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
🎁 Added hard reset directives to the RabbitMQ connections, so the pods restart whenever the soft resets fails too many times, so the whole system status is clear for the user and some other edge cases are solved by just restarting every pod that needs a connection to the RabbitMQ Cluster
```

