### PR TITLE
removing parse url from the get rabbitmqUrl function

### DIFF
--- a/pkg/rabbit/exchange.go
+++ b/pkg/rabbit/exchange.go
@@ -17,8 +17,6 @@ limitations under the License.
 package rabbit
 
 import (
-	"net/url"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing-rabbitmq/pkg/apis/sources/v1alpha1"
 	"knative.dev/pkg/kmeta"
@@ -33,7 +31,7 @@ type ExchangeArgs struct {
 	Namespace                string
 	RabbitMQVhost            string
 	RabbitmqClusterReference *rabbitv1beta1.RabbitmqClusterReference
-	RabbitMQURL              *url.URL
+	RabbitMQURL              string
 	Broker                   *eventingv1.Broker
 	Trigger                  *eventingv1.Trigger
 	Source                   *v1alpha1.RabbitmqSource

--- a/pkg/rabbit/secret_test.go
+++ b/pkg/rabbit/secret_test.go
@@ -25,7 +25,6 @@ import (
 	"knative.dev/eventing-rabbitmq/pkg/apis/sources/v1alpha1"
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 
-	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	_ "knative.dev/pkg/system/testing"
 )
@@ -40,11 +39,6 @@ const (
 
 func TestMakeSecret(t *testing.T) {
 	var TrueValue = true
-	url, err := apis.ParseURL(testRabbitURL)
-	if err != nil {
-		t.Errorf("Failed to parse the test URL: %s", err)
-	}
-
 	for _, tt := range []struct {
 		name string
 		args *ExchangeArgs
@@ -54,7 +48,7 @@ func TestMakeSecret(t *testing.T) {
 			name: "test broker secret name",
 			args: &ExchangeArgs{
 				Broker:      &eventingv1.Broker{ObjectMeta: metav1.ObjectMeta{Name: brokerName, Namespace: ns}},
-				RabbitMQURL: url.URL(),
+				RabbitMQURL: testRabbitURL,
 			},
 			want: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -79,7 +73,7 @@ func TestMakeSecret(t *testing.T) {
 			name: "test source secret name",
 			args: &ExchangeArgs{
 				Source:      &v1alpha1.RabbitmqSource{ObjectMeta: metav1.ObjectMeta{Name: sourceName, Namespace: ns}},
-				RabbitMQURL: url.URL(),
+				RabbitMQURL: testRabbitURL,
 			},
 			want: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -115,7 +109,7 @@ func TestMakeSecret(t *testing.T) {
 				owner = tt.args.Source
 				name = tt.args.Source.Name
 			}
-			got := MakeSecret(name, typeString, ns, tt.args.RabbitMQURL.String(), owner)
+			got := MakeSecret(name, typeString, ns, tt.args.RabbitMQURL, owner)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Error("unexpected diff (-want, +got) = ", diff)
 			}

--- a/pkg/rabbit/service_test.go
+++ b/pkg/rabbit/service_test.go
@@ -125,6 +125,18 @@ func Test_RabbitMQURL(t *testing.T) {
 		secretData: map[string][]byte{"uri": []byte("https://test-uri"), "password": []byte("1234"), "username": []byte("test"), "port": []byte("1234")},
 		wantUrl:    "amqps://test:1234@test-uri:1234",
 		wantErr:    false,
+	}, {
+		name:       "username with /",
+		conSecret:  true,
+		secretData: map[string][]byte{"uri": []byte("https://test-uri:5678"), "password": []byte("1234"), "username": []byte("my//domain/test"), "port": []byte("1234")},
+		wantUrl:    "amqps://my//domain/test:1234@test-uri:1234",
+		wantErr:    false,
+	}, {
+		name:       "username with \\",
+		conSecret:  true,
+		secretData: map[string][]byte{"uri": []byte("https://test-uri:5678"), "password": []byte("1234"), "username": []byte("mydomain\\test"), "port": []byte("1234")},
+		wantUrl:    "amqps://mydomain\\test:1234@test-uri:1234",
+		wantErr:    false,
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			tt := tt
@@ -149,7 +161,7 @@ func Test_RabbitMQURL(t *testing.T) {
 			gotUrl, err := r.RabbitMQURL(ctx, cr)
 			if (err != nil && !tt.wantErr) || (err == nil && tt.wantErr) {
 				t.Errorf("unexpected error checking conditions want: %v, got: %v", tt.wantErr, err)
-			} else if !tt.wantErr && gotUrl.String() != tt.wantUrl {
+			} else if !tt.wantErr && gotUrl != tt.wantUrl {
 				t.Errorf("got wrong url want: %s, got: %s", tt.wantUrl, gotUrl)
 			}
 		})

--- a/pkg/rabbit/types.go
+++ b/pkg/rabbit/types.go
@@ -18,7 +18,6 @@ package rabbit
 
 import (
 	"context"
-	"net/url"
 
 	rabbitv1beta1 "knative.dev/eventing-rabbitmq/third_party/pkg/apis/rabbitmq.com/v1beta1"
 )
@@ -29,7 +28,7 @@ type Result struct {
 }
 
 type Service interface {
-	RabbitMQURL(context.Context, *rabbitv1beta1.RabbitmqClusterReference) (*url.URL, error)
+	RabbitMQURL(context.Context, *rabbitv1beta1.RabbitmqClusterReference) (string, error)
 	ReconcileExchange(context.Context, *ExchangeArgs) (Result, error)
 	ReconcileQueue(context.Context, *QueueArgs) (Result, error)
 	ReconcileBinding(context.Context, *BindingArgs) (Result, error)

--- a/pkg/reconciler/broker/broker.go
+++ b/pkg/reconciler/broker/broker.go
@@ -290,7 +290,7 @@ func (r *Reconciler) reconcileRabbitResources(ctx context.Context, b *eventingv1
 
 	return r.reconcileCommonIngressResources(
 		ctx,
-		rabbit.MakeSecret(args.Broker.Name, "broker", args.Namespace, args.RabbitMQURL.String(), args.Broker),
+		rabbit.MakeSecret(args.Broker.Name, "broker", args.Namespace, args.RabbitMQURL, args.Broker),
 		b,
 		args.RabbitMQVhost,
 	)

--- a/pkg/reconciler/source/rabbitmqsource.go
+++ b/pkg/reconciler/source/rabbitmqsource.go
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcileRabbitObjects(ctx context.Context, src *v1alpha1.R
 		return err
 	}
 
-	if err := rabbit.ReconcileSecret(ctx, r.secretLister, r.KubeClientSet, rabbit.MakeSecret(src.Name, "source", src.Namespace, rabbitmqURL.String(), src)); err != nil {
+	if err := rabbit.ReconcileSecret(ctx, r.secretLister, r.KubeClientSet, rabbit.MakeSecret(src.Name, "source", src.Namespace, rabbitmqURL, src)); err != nil {
 		logging.FromContext(ctx).Errorw("Problem reconciling Secret", zap.Error(err))
 		src.Status.MarkSecretFailed("SecretFailure", "Failed to reconcile secret: %s", err)
 		return err


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- 🎁 Now Brokers and Sources accept broader rabbitmq url usernames and passwords characters to connect to RabbitMQ instances

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1216

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Now Brokers and Sources accept broader rabbitmq url usernames and passwords characters to connect to RabbitMQ instances
```
